### PR TITLE
Get rid of bluebird

### DIFF
--- a/lib/concurrency-master.js
+++ b/lib/concurrency-master.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var Promise = require('bluebird');
-
 // The concurrency master! Initialize with a positive integer
 // concurrency value, then call add() on functions that return
 // promises, and it'll call them all subject to the constraint

--- a/package.json
+++ b/package.json
@@ -16,7 +16,5 @@
     "chai": "^3.5.0",
     "mocha": "^2.4.5"
   },
-  "dependencies": {
-    "bluebird": "^3.2.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
There's no need for this heavyweight external Promise
library dependency in this lightweight scheduler.

@demmer
